### PR TITLE
Updated handling of invalid input

### DIFF
--- a/lib/json/index.js
+++ b/lib/json/index.js
@@ -10,7 +10,7 @@ function json(text) {
                 return resolve(JSON.stringify(text, null, this.step));
             }
 
-            return resolve(null);
+            throw new TypeError('Input must of type "object" or "string"');
         } catch (e) {
             return reject(e);
         }
@@ -22,20 +22,22 @@ function jsonmin(text) {
     return new Promise((resolve, reject) => {
         try {
             return resolve(
-                text.replace(/\s{0,}\{\s{0,}/g, "{")
-                .replace(/\s{0,}\[$/g, "[")
-                .replace(/\[\s{0,}/g, "[")
-                .replace(/:\s{0,}\[/g, ':[')
-                .replace(/\s{0,}\}\s{0,}/g, "}")
-                .replace(/\s{0,}\]\s{0,}/g, "]")
-                .replace(/\"\s{0,}\,/g, '",')
-                .replace(/\,\s{0,}\"/g, ',"')
-                .replace(/\"\s{0,}:/g, '":')
-                .replace(/:\s{0,}\"/g, ':"')
-                .replace(/:\s{0,}\[/g, ':[')
-                .replace(/\,\s{0,}\[/g, ',[')
-                .replace(/\,\s{2,}/g, ', ')
-                .replace(/\]\s{0,},\s{0,}\[/g, '],[')
+                text
+                    .toString()
+                    .replace(/\s{0,}\{\s{0,}/g, "{")
+                    .replace(/\s{0,}\[$/g, "[")
+                    .replace(/\[\s{0,}/g, "[")
+                    .replace(/:\s{0,}\[/g, ':[')
+                    .replace(/\s{0,}\}\s{0,}/g, "}")
+                    .replace(/\s{0,}\]\s{0,}/g, "]")
+                    .replace(/\"\s{0,}\,/g, '",')
+                    .replace(/\,\s{0,}\"/g, ',"')
+                    .replace(/\"\s{0,}:/g, '":')
+                    .replace(/:\s{0,}\"/g, ':"')
+                    .replace(/:\s{0,}\[/g, ':[')
+                    .replace(/\,\s{0,}\[/g, ',[')
+                    .replace(/\,\s{2,}/g, ', ')
+                    .replace(/\]\s{0,},\s{0,}\[/g, '],[')
             );
         } catch (e) {
             return reject(e);

--- a/test/json.test.js
+++ b/test/json.test.js
@@ -32,4 +32,12 @@ describe('json', () => {
 
         should(SweetData.json(invalidJson)).be.rejected();
     });
+
+    it('should reject the promise on invalid json input with TypeError', () => {
+        const invalidJson = 123;
+
+        const typeError = new TypeError('Input must of type "object" or "string"');
+
+        should(SweetData.json(invalidJson)).be.rejectedWith(typeError);
+    });
 });

--- a/test/jsonmin.test.js
+++ b/test/jsonmin.test.js
@@ -26,10 +26,4 @@ describe('jsonmin', () => {
 
         should(SweetData.jsonmin(json)).be.fulfilledWith(expected);
     });
-
-    it('should reject the promise on invalid json input', () => {
-        const invalidJson = 123;
-
-        should(SweetData.jsonmin(invalidJson)).be.rejected();
-    });
 })


### PR DESCRIPTION
Upated json() to throw a TypeError if input is not string or object rather than returning null. Updated jsonmin() to attempt to transform to string prior to attempting string method such as replace(). This would be handled in .catch() of consumer.